### PR TITLE
file_to_snowflake_table_comparison

### DIFF
--- a/file_to_table_comparison_template.ipynb
+++ b/file_to_table_comparison_template.ipynb
@@ -1,0 +1,391 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a6f1268e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install msal"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2559f0c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install snowflake-connector-python snowflake-sqlalchemy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85ca65ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import snowflake.connector\n",
+    "conn=snowflake.connector.connect(\n",
+    "    user=\"ROHIT.JONNADULA@gmail.COM\",\n",
+    "    account=\"account_identifier\",\n",
+    "    authenticator=\"externalbrowser\",\n",
+    "    warehouse = \"<none selected>\",\n",
+    "    database = \"<none selected>\",\n",
+    "    schema = \"<none selected>\",\n",
+    "    role=\"role\"\n",
+    "    )\n",
+    "cur=conn.cursor()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1e173373",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cur.execute(\"use warehouse warehouse_name\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db99ce1b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cur.execute(\"desc table catalog.schema.table_name\")\n",
+    "desc=cur.fetchall()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "71e0d6c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "00470b21",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install fsspec"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5ccdb02e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install tabulate\n",
+    "from tabulate import tabulate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8f50cff5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "\n",
+    "file_format_options = {\n",
+    "    \"TYPE\": \"CSV\",\n",
+    "    \"RECORD_DELIMITER\": \"\\n\",\n",
+    "    \"FIELD_DELIMITER\": \",\",\n",
+    "    \"SKIP_HEADER\": 0,\n",
+    "    \"PARSE_HEADER\": True,\n",
+    "    \"DATE_FORMAT\": \"AUTO\",\n",
+    "    \"TIME_FORMAT\": \"AUTO\",\n",
+    "    \"TIMESTAMP_FORMAT\": \"AUTO\",\n",
+    "    \"BINARY_FORMAT\": \"HEX\",\n",
+    "    \"ESCAPE\": \"NONE\",\n",
+    "    \"ESCAPE_UNENCLOSED_FIELD\": \"\\\\\",\n",
+    "    \"TRIM_SPACE\": True,\n",
+    "    \"FIELD_OPTIONALLY_ENCLOSED_BY\": \"\\\"\",\n",
+    "    \"NULL_IF\": [\"NULL\", \"null\", \"\"],\n",
+    "    \"COMPRESSION\": \"NONE\",\n",
+    "    \"ERROR_ON_COLUMN_COUNT_MISMATCH\": True,\n",
+    "    \"VALIDATE_UTF8\": True,\n",
+    "    \"SKIP_BLANK_LINES\": True,\n",
+    "    \"REPLACE_INVALID_CHARACTERS\": True,\n",
+    "    \"EMPTY_FIELD_AS_NULL\": True,\n",
+    "    \"SKIP_BYTE_ORDER_MARK\": True,\n",
+    "    \"ENCODING\": \"UTF8\",\n",
+    "    \"MULTI_LINE\": True,\n",
+    "    \"dtype\": str\n",
+    "    # \"column_names\": col_names\n",
+    "}\n",
+    "\n",
+    "# Map Snowflake options to pandas read_csv parameters\n",
+    "read_csv_params = {\n",
+    "    \"sep\": file_format_options[\"FIELD_DELIMITER\"],\n",
+    "    \"header\": 0 if file_format_options[\"PARSE_HEADER\"] else None,\n",
+    "    \"skiprows\": file_format_options[\"SKIP_HEADER\"],\n",
+    "    \"quotechar\": file_format_options[\"FIELD_OPTIONALLY_ENCLOSED_BY\"],\n",
+    "    \"escapechar\": file_format_options[\"ESCAPE_UNENCLOSED_FIELD\"],\n",
+    "    \"encoding\": file_format_options[\"ENCODING\"],\n",
+    "    \"na_values\": file_format_options[\"NULL_IF\"],\n",
+    "    \"skip_blank_lines\": file_format_options[\"SKIP_BLANK_LINES\"],\n",
+    "    \"engine\": \"python\" if file_format_options[\"MULTI_LINE\"] else \"c\",\n",
+    "    \"dtype\": file_format_options[\"dtype\"]\n",
+    "    # \"names\": file_format_options[\"column_names\"]\n",
+    "}\n",
+    "\n",
+    "# Example usage: replace 'your_file.csv' with your actual file path\n",
+    "df_file = pd.read_csv(\"C://Users/rohit.jonnadula/Downloads/file_name\", **read_csv_params)\n",
+    "\n",
+    "# Show the DataFrame\n",
+    "print(df_file.head())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dc9b1b55",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "col_names=df_file.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ef0856b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "select_query='select '+','.join(col_names)+' from catalog.schema.table_name'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2efea08d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "select_query"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ffa4c224",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cur.execute(select_query)\n",
+    "data=cur.fetchall()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e88e7eb9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_table=pd.DataFrame(data, columns=col_names)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "295034b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_file.count()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d0d65615",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_table.count()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bb76dd28",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_table.dtypes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4f086fbe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_file.dtypes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "340a63f7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_table = df_table.reset_index(drop=True)\n",
+    "df_file = df_file.reset_index(drop=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9bfb3c40",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for col in df_table.select_dtypes(include='object'):\n",
+    "       df_table[col] = df_table[col].str.strip()\n",
+    "       df_file[col] = df_file[col].str.strip()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5739e553",
+   "metadata": {
+    "vscode": {
+     "languageId": "xml"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df_minus_alt = pd.concat([df_table, df_file, df_file]).drop_duplicates(keep=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a194f623",
+   "metadata": {
+    "vscode": {
+     "languageId": "xml"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df_minus_alt.count()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14260bb3",
+   "metadata": {
+    "vscode": {
+     "languageId": "xml"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print(tabulate(df_minus_alt, headers='keys', tablefmt='psql'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6bc0e212",
+   "metadata": {
+    "vscode": {
+     "languageId": "xml"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "#backtracking\n",
+    "result = pd.concat(\n",
+    "\t[\n",
+    "\t\tdf_table[(df_table[\"col1\"] == '20703') & (df_table[\"col2\"] == '63885') & (df_table[\"col3\"]=='5')],\n",
+    "\t\tdf_file[(df_file[\"col1\"] == '20703') & (df_file[\"col2\"] == '63885') & (df_file[\"col3\"]=='5')]\n",
+    "\t],\n",
+    "\tignore_index=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4e6af583",
+   "metadata": {
+    "vscode": {
+     "languageId": "xml"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print(tabulate(result, headers='keys', tablefmt='psql'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8eb891a4",
+   "metadata": {
+    "vscode": {
+     "languageId": "xml"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print(df_minus_alt)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f3cf5ff5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cur.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This is a Jupyter notebook. In this notebook, I have identified common problems encountered when comparing files and tables.

Most data engineers load files into the bronze layer by creating file formats, defining stages, and loading data into tables. However, there is a catch: if an engineer forgets to specify certain options when creating file formats—such as fields enclosed by `"`, row delimiter as `\n`, treating stringified nulls as actual nulls, or properly handling special characters—it can seriously affect the data quality.

To ensure data is loaded correctly into the bronze layer, engineers can use this notebook to quickly validate their data loads. I hope this will be helpful.