### PR TITLE
Add files via upload

### DIFF
--- a/SP_SCD1_to_SCD2_CONVERSION.sql
+++ b/SP_SCD1_to_SCD2_CONVERSION.sql
@@ -1,0 +1,104 @@
+CREATE OR REPLACE PROCEDURE SP_SCD2_DYNAMIC_LOAD(
+    p_raw_table_name STRING,
+    p_silver_table_name STRING,
+    p_business_keys STRING  -- e.g. 'customer_id,region_id'
+)
+RETURNS STRING
+LANGUAGE SQL
+AS
+$$
+DECLARE
+    v_keys_partition_clause STRING;
+    v_keys_join_clause STRING;
+    v_step1_sql STRING;
+    v_step2_sql STRING;
+    v_step3_sql STRING;
+    v_step4_sql STRING;
+BEGIN
+
+  -- Build dynamic clauses
+  LET v_keys_partition_clause = p_business_keys;
+  LET v_keys_join_clause = ARRAY_TO_STRING(
+    ARRAY_AGG(
+      's.' || value || ' = sl.' || value
+    ) OVER (),
+    ' AND '
+  )
+  FROM TABLE(SPLIT_TO_TABLE(p_business_keys, ','));
+
+  -- STEP 1: Create temp table with all raw except latest
+  LET v_step1_sql = '
+    CREATE OR REPLACE TEMP TABLE raw_except_latest AS
+    SELECT *
+    FROM ' || p_raw_table_name || '
+    QUALIFY ROW_NUMBER() OVER (PARTITION BY ' || v_keys_partition_clause || ' ORDER BY load_timestamp DESC) > 1;
+  ';
+  EXECUTE IMMEDIATE v_step1_sql;
+
+  -- STEP 2: Update silver records with 2nd latest load_timestamp from raw
+  LET v_step2_sql = '
+    WITH second_latest_raw AS (
+      SELECT ' || p_business_keys || ', load_timestamp AS second_latest_load_ts
+      FROM (
+        SELECT *,
+               ROW_NUMBER() OVER (PARTITION BY ' || v_keys_partition_clause || ' ORDER BY load_timestamp DESC) AS rn
+        FROM ' || p_raw_table_name || '
+      )
+      WHERE rn = 2
+    )
+    UPDATE ' || p_silver_table_name || ' AS s
+    SET 
+      start_date = sl.second_latest_load_ts::DATE,
+      end_date = NULL,
+      is_current = TRUE
+    FROM second_latest_raw AS sl
+    WHERE ' || v_keys_join_clause || ';
+  ';
+  EXECUTE IMMEDIATE v_step2_sql;
+
+  -- STEP 3: Insert historical versions
+  LET v_step3_sql = '
+    INSERT INTO ' || p_silver_table_name || ' (
+      customer_id, name, address, phone,
+      load_timestamp, start_date, end_date, is_current
+    )
+    SELECT 
+      customer_id, name, address, phone,
+      load_timestamp,
+      load_timestamp::DATE AS start_date,
+      DATEADD(DAY, -1, LEAD(load_timestamp) OVER (PARTITION BY ' || v_keys_partition_clause || ' ORDER BY load_timestamp))::DATE AS end_date,
+      FALSE AS is_current
+    FROM raw_except_latest;
+  ';
+  EXECUTE IMMEDIATE v_step3_sql;
+
+  -- STEP 4: Handle single-record customers
+  LET v_step4_sql = '
+    WITH single_version_customers AS (
+      SELECT *
+      FROM (
+        SELECT *,
+               COUNT(*) OVER (PARTITION BY ' || v_keys_partition_clause || ') AS version_count,
+               ROW_NUMBER() OVER (PARTITION BY ' || v_keys_partition_clause || ' ORDER BY load_timestamp DESC) AS rn
+        FROM ' || p_raw_table_name || '
+      )
+      WHERE version_count = 1 AND rn = 1
+    )
+    INSERT INTO ' || p_silver_table_name || ' (
+      customer_id, name, address, phone,
+      load_timestamp, start_date, end_date, is_current
+    )
+    SELECT 
+      customer_id, name, address, phone,
+      load_timestamp,
+      load_timestamp::DATE AS start_date,
+      NULL AS end_date,
+      TRUE AS is_current
+    FROM single_version_customers;
+  ';
+  EXECUTE IMMEDIATE v_step4_sql;
+
+  RETURN 'Dynamic SCD Type 2 Load Completed';
+
+END;
+$$;


### PR DESCRIPTION
Converting a Type 1 to a Type 2 Slowly Changing Dimension (SCD)
This procedure outlines how to convert a SCD Type 1 table to a SCD Type 2 table using a data pipeline based on a medallion architecture.

Key Architectural and Data Flow Concepts
Medallion Architecture: The process utilizes a three-tiered medallion architecture:

Bronze Layer: This layer holds all raw, source data files, including a load_timestamp column to track when each record was ingested. This is the source of all historical versions of the data.

Silver Layer: This is where the SCD Type 2 table is created. It's the core of the conversion process, where we transform the raw data into a structured historical record.

Gold Layer: While not directly part of this procedure, the final SCD Type 2 table would typically be presented here, ready for reporting and analysis.

Source Data: The raw data in the Bronze layer may contain multiple versions of the same record, identified by a unique key combination and differentiated by the load_timestamp.

Target Table: The goal is to create a new SCD Type 2 table in the Silver layer that preserves the full history of changes for each record.

The Conversion Process
The code automates the following steps:

Input: The procedure takes three main inputs: the source table name (from the Bronze layer), the key column combination that uniquely identifies a record, and the target table name for the new SCD Type 2 table.

Versioning: The code identifies all versions of a record in the raw data by grouping on the key column combination. The load_timestamp column is crucial for ordering these versions chronologically.

Historical Record Management: For each new version of a record, the process handles updates by:

"Soft deleting" the previous, older version of the record. This is done by updating its end_date and setting an is_current indicator to False.

Inserting the new version of the record with the latest data. This new record is marked as the current version with an is_current indicator of True.

Handling Unchanged Records: Records that have not changed in the latest load are left untouched, ensuring data integrity and optimizing performance by only processing new or updated records.

LEAD Function: The LEAD window function is used to efficiently determine the end_date for a previous version of a record. It looks ahead to the load_timestamp of the next version and sets the current record's end_date to that value.

This code provides a robust and structured method for transforming SCD Type 1 data into a full historical record (SCD Type 2). While the specific column names and architecture may need to be adapted, the underlying logic provides a reusable framework for this common data warehousing task.